### PR TITLE
Drowned God throne permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # damphair
 The sea never rests. You must be as tireless.
+
+
+The Drowned God does not permit godless men to sit his throne.


### PR DESCRIPTION
Updated Drowned God throne permissions to exclude godless men.